### PR TITLE
Added JSON message parsing

### DIFF
--- a/mqttGateway.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/mqttGateway.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -22,13 +22,26 @@
             <Field id="brokerTopic" type="textfield" defaultValue="device/status">
                 <Label>Topic:</Label>
             </Field>
-			<Field id="muteTopic" type="checkbox" defaultValue="false">
-				<Label>Disable topic update in Indigo Log</Label>
-			</Field>
+			      <Field id="muteTopic" type="checkbox" defaultValue="false">
+				        <Label>Disable topic update in Indigo Log</Label>
+			      </Field>
             <Field id="SupportsOnState" type="checkbox" defaultValue="true">
                 <Label>Show ON/OFF state:</Label>
             </Field>
             <Field id="separator2" type="separator"/>
+
+            <Field id="SupportsVariableInsert" type="checkbox" defaultValue="false">
+                <Label>Add value to variable:</Label>
+            </Field>
+            <Field id="insertInto" type="menu">
+                <Label>Insert in:</Label>
+                <List class="indigo.variables"/>
+            </Field>
+            <Field id="pathToData" type="textfield">
+                <Label>Enter path to data:</Label>
+            </Field>
+            <Field id="separator3" type="separator"/>
+
             <Field id="SupportsStatusRequest" type="checkbox" defaultValue="true">
                 <Label>Enable Status Request:</Label>
             </Field>


### PR DESCRIPTION
If a topic published json data, such as a sensor, there was no way to use that data in Indigo. A device can now subscribe to a topic and parse though the json data in the message.

Just enable "Add value to variable", choose your desired variable in the drop down, and then specify the path to your value. For example, my device is sending the following JSON message: `{"Time":"2017-07-19T00:57:38", "AM2301":{"Temperature":77.4, "Humidity":51.2}, "TempUnit":"F"}` In order to get to the temperature value you just specify all of the keys that are needed in the proper order. So in my case it would be get the value of `AM2301` and then the value of `Temperature`. This translates to `AM2301->Temperature`. If I simply wanted the time, then my "path to data" would be: `Time`

![screen shot 2017-07-18 at 8 01 36 pm](https://user-images.githubusercontent.com/3443748/28344800-f75a93e0-6bf3-11e7-9841-0f911d17a9fc.png)